### PR TITLE
Update autoTree.py

### DIFF
--- a/autoTree.py
+++ b/autoTree.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 import os
 from functools import reduce
 import argparse


### PR DESCRIPTION
Fix: SyntaxError: Non-ASCII character '\xe2' in file autoTree.py on line 49, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details